### PR TITLE
Fix bug decryptor "RNCryptorError error 2" in ios, when encryptor in Android

### DIFF
--- a/rncryptor-native/src/main/jni/rncryptor-native.cpp
+++ b/rncryptor-native/src/main/jni/rncryptor-native.cpp
@@ -84,8 +84,9 @@ jbyteArray Java_tgio_rncryptor_RNCryptorNative_encrypt(JNIEnv *env, jobject inst
 }
 
 
-jstring Java_tgio_rncryptor_RNCryptorNative_decrypt(JNIEnv *env, jobject instance, jstring encrypted_, jstring password_) {
-    string decrypted = "0";
+jbyteArray Java_tgio_rncryptor_RNCryptorNative_decrypt(JNIEnv *env, jobject instance,
+                                                       jstring encrypted_, jstring password_) {
+    std::string decrypted;
     if (encrypted_ != NULL) {
         try {
             const char *encrypted = env->GetStringUTFChars(encrypted_, 0);
@@ -95,9 +96,12 @@ jstring Java_tgio_rncryptor_RNCryptorNative_decrypt(JNIEnv *env, jobject instanc
             delete cryptor;
             env->ReleaseStringUTFChars(encrypted_, encrypted);
             env->ReleaseStringUTFChars(password_, password);
+            jbyteArray array = env->NewByteArray((jsize) decrypted.size());
+            env->SetByteArrayRegion(array, 0, (jsize) decrypted.size(), (const jbyte *) decrypted.c_str());
+            return array;
         } catch (exception e) {
             decrypted = "error decrypting";
         }
     }
-    return env->NewStringUTF(decrypted.c_str());
+    return NULL;
 }

--- a/rncryptor-native/src/main/jni/rncryptor-native.h
+++ b/rncryptor-native/src/main/jni/rncryptor-native.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif
     JNIEXPORT jstring JNICALL Java_tgio_rncryptor_RNCryptorNative_getABI(JNIEnv* env, jobject thiz);
     JNIEXPORT jbyteArray JNICALL Java_tgio_rncryptor_RNCryptorNative_encrypt(JNIEnv *env, jobject instance, jstring raw_, jstring password_);
-    JNIEXPORT jstring JNICALL Java_tgio_rncryptor_RNCryptorNative_decrypt(JNIEnv *env, jobject instance, jstring encrypted_, jstring password_);
+    JNIEXPORT jbyteArray JNICALL Java_tgio_rncryptor_RNCryptorNative_decrypt(JNIEnv *env, jobject instance, jstring encrypted_, jstring password_);
 #ifdef __cplusplus
 }
 #endif

--- a/rncryptor-native/src/main/jni/rncryptor.cpp
+++ b/rncryptor-native/src/main/jni/rncryptor.cpp
@@ -35,7 +35,7 @@ using CryptoPP::Base64Encoder;
 using CryptoPP::Base64Decoder;
 
 RNCryptor::RNCryptor() {
-	configureSettings(SCHEMA_2);
+	configureSettings(SCHEMA_3);
 }
 
 void RNCryptor::configureSettings(RNCryptorSchema schemaVersion)
@@ -59,6 +59,7 @@ void RNCryptor::configureSettings(RNCryptorSchema schemaVersion)
 			break;
 
 		case SCHEMA_2:
+		case SCHEMA_3:
 			aesMode = MODE_CBC;
 			options = OPTIONS_1;
 			hmac_includesHeader = true;

--- a/rncryptor-native/src/main/jni/rncryptor.h
+++ b/rncryptor-native/src/main/jni/rncryptor.h
@@ -27,7 +27,7 @@ enum RNCryptorAlgorithm {
 };
 
 enum RNCryptorSchema {
-	SCHEMA_0, SCHEMA_1, SCHEMA_2
+	SCHEMA_0, SCHEMA_1, SCHEMA_2, SCHEMA_3
 };
 
 enum RNCryptorOptions {

--- a/rncryptor-native/src/main/jni/rnencryptor.h
+++ b/rncryptor-native/src/main/jni/rnencryptor.h
@@ -11,7 +11,7 @@ class RNEncryptor : public RNCryptor {
 	string generateSalt();
 
 	public:
-		string encrypt(string plaintext, string password, RNCryptorSchema schemaVersion = SCHEMA_2);
+		string encrypt(string plaintext, string password, RNCryptorSchema schemaVersion = SCHEMA_3);
 };
 
 #endif


### PR DESCRIPTION
In Android when you want to encrypt the text, you have to use SCHEMA_3 for encryption. Decryptor in Swift cannot identify the Schema Version of Base 64 encoded string.
